### PR TITLE
Replace state: installed to present

### DIFF
--- a/tasks/tasks-CentOS.yml
+++ b/tasks/tasks-CentOS.yml
@@ -3,7 +3,7 @@
 - name: "Go-Lang | Install dependencies"
   yum:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - curl
     - gcc

--- a/tasks/tasks-Debian.yml
+++ b/tasks/tasks-Debian.yml
@@ -3,7 +3,7 @@
 - name: "Go-Lang | Install dependencies"
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - curl
     - gcc

--- a/tasks/tasks-RedHat.yml
+++ b/tasks/tasks-RedHat.yml
@@ -3,7 +3,7 @@
 - name: "Go-Lang | Install dependencies"
   dnf:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - curl
     - gcc


### PR DESCRIPTION
In ansible 2.5, `Go-Lang | Install dependencies` task gets below warning.

```
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead.. This feature will be removed in version 2.9. Deprecation warnings can be disabled by
 setting deprecation_warnings=False in ansible.cfg.
```