### PR TITLE
PR for #96

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,10 @@ env:
     init: /sbin/init
     run_opts: --privileged
     playbook: test.yml
-  - distro: centos-6
-    init: /sbin/init
-    run_opts: --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro
-    playbook: test.yml
+#  - distro: centos-6
+#    init: /sbin/init
+#    run_opts: --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro
+#    playbook: test.yml
   - distro: centos-7
     init: /usr/lib/systemd/systemd
     run_opts: --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - buster
     - name: EL
       versions:
-        - 6
+#        - 6
         - 7
     - name: Fedora
       versions:


### PR DESCRIPTION
Removes the test for Cent OS 6 and official support to fast-track build times as any involvement with CentOS is hindering the project in terms of speed and turnover.