### PR TITLE
PR for #98

### DIFF
--- a/tasks/go-get.yml
+++ b/tasks/go-get.yml
@@ -23,5 +23,6 @@
   environment:
     GOPATH: "{{ GOPATH }}"
     GOROOT: "{{ GOROOT }}"
+    GO111MODULE: ""
   with_items: "{{ go_get }}"
   changed_when: false


### PR DESCRIPTION
This PR resolved #98. It ensures `go get` commands don't fail (in isolation or unanimously) after go 1.11 or later is installed using the role - it does not impact the environment or shell otherwise but ensures backwards compatibility for the selected go version and configuration of this role