### PR TITLE
Fix packages list for package managers

### DIFF
--- a/tasks/tasks-CentOS.yml
+++ b/tasks/tasks-CentOS.yml
@@ -2,14 +2,7 @@
 
 - name: "Go-Lang | Install dependencies"
   yum:
-    name:
-      - curl
-      - gcc
-      - git
-      - findutils
-      - make
-      - rsync
-      - tar
+    name: ['curl', 'gcc', 'git', 'findutils', 'make', 'rsync', 'tar']
     state: present
 
 - name: "Go-Lang | Define GOARCH"

--- a/tasks/tasks-Debian.yml
+++ b/tasks/tasks-Debian.yml
@@ -2,14 +2,7 @@
 
 - name: "Go-Lang | Install dependencies"
   apt:
-    pkg:
-      - curl
-      - gcc
-      - git
-      - findutils
-      - make
-      - rsync
-      - tar
+    pkg: [ 'curl', 'gcc', 'git', 'findutils', 'make', 'rsync', 'tar' ]
     state: present
 
 - name: "Go-Lang | Define GOARCH"

--- a/tasks/tasks-RedHat.yml
+++ b/tasks/tasks-RedHat.yml
@@ -2,17 +2,9 @@
 
 - name: "Go-Lang | Install dependencies"
   dnf:
-    name: "{{ item }}"
+    name: [ 'curl', 'gcc', 'git', 'findutils', 'make', 'rsync', 'tar' ]
     state: present
-  with_items:
-    - curl
-    - gcc
-    - git
-    - findutils
-    - make
-    - rsync
-    - tar
-
+  
 - name: "Go-Lang | Define GOARCH"
   set_fact:
     GOARCH: "amd64"


### PR DESCRIPTION
While using the playbook for installing Go on Centos 7, I got this deprecation warning:

> [DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to 
> supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['curl', 'gcc', 'git', 'findutils', 'make', 'rsync', 
> 'tar']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting 
> deprecation_warnings=False in ansible.cfg.

I've changed the tasks/CentOS.yml file to reflect the deprecation, and did the same for the other files.