### PR TITLE
Official support for GO111MODULE

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ GOROOT: /usr/local/go
 
 Optional configuration
 ````yaml
+GO111MODULE: "on" # Needs to be of type string, not on/off which will be handled as a boolean.
 GOOS: darwin
 GOARCH: amd64
 go_checksum: sha256:82628a1a42d7ad88b100d0c4c9c0282a7e008e4eb73876bed4bd61ac4ee11b46

--- a/tasks/go-get.yml
+++ b/tasks/go-get.yml
@@ -23,6 +23,6 @@
   environment:
     GOPATH: "{{ GOPATH }}"
     GOROOT: "{{ GOROOT }}"
-    GO111MODULE: ""
+    GO111MODULE: "{{ GO111MODULE }}"
   with_items: "{{ go_get }}"
   changed_when: false

--- a/tasks/go-install.yml
+++ b/tasks/go-install.yml
@@ -16,7 +16,7 @@
   environment:
     GOROOT: "{{ GOROOT }}"
     GOPATH: "{{ GOPATH }}"
-    GO111MODULE: "on"
+    GO111MODULE: "{{ GO111MODULE }}"
   args:
     chdir: "{{ GOPATH }}/src/{{ item.dest }}"
   with_items: "{{ go_install }}"
@@ -27,5 +27,6 @@
   environment:
     GOROOT: "{{ GOROOT }}"
     GOPATH: "{{ GOPATH }}"
+    GO111MODULE: "{{ GO111MODULE }}"
   with_items: "{{ go_install }}"
   changed_when: false

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -43,6 +43,11 @@
     - ansible_os_family == "RedHat"
     - ansible_distribution != "CentOS"
 
+- name: "Go-Lang | Define GO111MODULE"
+  set_fact:
+    GO111MODULE: "on"
+  when: GO111MODULE is not defined
+
 - name: "Go-Lang | Define GOROOT"
   set_fact:
     GOROOT: /usr/local/go

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -11,6 +11,7 @@
     GOROOT: /home/travis/goroot1.9
     GOPATH: /home/travis/gopath
     GOROOT_BOOTSTRAP: /home/travis/goroot1.4
+    GO111MODULE: "off"
 
   pre_tasks:
     - file:


### PR DESCRIPTION
Won't be used or needed for long - we'll be able to default to true in a short while, but it will help intermediate configuration with packages which haven't been updated to include module support and running `go get`.

It's an officially supported mechanism, and it makes sense.