### PR TITLE
Clearer go installation and support custom package for `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ go_install:
   dest: github.com/fubarhouse/dvm
   # version refers to a tag, or branch.
   version: 2.2.5
+  package: github.com/fubarhouse/dvm
 ````
 
 To ensure all packages are removed before running the play, you can use the go_reget variable:

--- a/tasks/go-install.yml
+++ b/tasks/go-install.yml
@@ -24,7 +24,7 @@
   changed_when: false
 
 - name: "Go-Lang | Install packages"
-  command: "{{ GOROOT }}/bin/go install {{ item.dest }}/..."
+  command: "{{ GOROOT }}/bin/go install {{ item.package }}/..."
   environment:
     GOROOT: "{{ GOROOT }}"
     GOPATH: "{{ GOPATH }}"

--- a/tasks/install-distro.yml
+++ b/tasks/install-distro.yml
@@ -28,16 +28,12 @@
 
 - name: "Go-Lang | Removing existing installation"
   file:
-    path: "{{ GOROOT }}/{{ item }}"
+    path: "{{ GOROOT }}"
     state: absent
-  with_items:
-    - bin
-    - pkg
-    - src
   when: not build_go_from_source
 
 - name: "Go-Lang | Moving to installation directory"
-  command: "cp -rf {{ go_temporary_dir }}/go/* {{ GOROOT }}/"
+  command: "mv -f {{ go_temporary_dir }}/go {{ GOROOT }}"
   when: not build_go_from_source
 
 - name: "Go-Lang | Remove temporary data"


### PR DESCRIPTION
## Clearer go installation
### Problem:
1. with vagrant - ubuntu 16.04. File not found when using copy.
2. Copy take a lot of time.
Solution: Using `mv` instead of `cp`
## Custom package for `go install`
There was time people want to install in custom package. Say: github.com/any_repo/my_client/cmd
So go_install should be:

```yaml
    go_install:
      # repo is the git clone url, ssh or https.
    - repo: https://github.com/mholt/caddy
      # dest is the namespace
      dest: github.com/mholt/caddy
      # version refers to a tag, or branch.
      version: "master"
      # package is the package you want to build.
      github.com/mholt/caddy/caddy in this case
      package: github.com/mholt/caddy
```

