### PR TITLE
Remove | cat from go version command

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -123,7 +123,7 @@
   failed_when: false
 
 - name: "Go-Lang | Getting version information"
-  command: "{{ GOROOT }}/bin/go version | cat"
+  command: "{{ GOROOT }}/bin/go version"
   environment:
     GOPATH: "{{ GOPATH }}"
     GOROOT: "{{ GOROOT }}"


### PR DESCRIPTION
This fails with stderr like:

usage: go version\nRun 'go help version' for details

Consequently if you have an old version installed re-applying the
role does not upgrade it.