### PR TITLE
Auto create golang_shell_profile file

### DIFF
--- a/tasks/install-shell.yml
+++ b/tasks/install-shell.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Go_Lang | create configured shell profile
+  file:
+    path: "{{ golang_shell_profile }}"
+    state: touch
+  when:
+    - golang_shell_profile is defined
+
 - name: "Go_Lang | Identify if configured shell profile exists"
   stat:
     path: "{{ golang_shell_profile }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
     GOROOT: /home/travis/goroot1.9
     GOPATH: /home/travis/gopath
     GOROOT_BOOTSTRAP: /home/travis/goroot1.4
+    golang_shell_profile: /etc/profile.d/go.sh
     GO111MODULE: "on"
     go_get:
       # Test install package with no modules config (default):


### PR DESCRIPTION
It would be better to auto-create the shell profile script other than check if it's already exists