### PR TITLE
Add new param to prevent GOPATH being deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ To clean up an installation completely prior to role execution:
 ````yaml
 go_install_clean: true
 ````
+
+To prevent clean up from removing GOPATH
+````yaml
+go_install_clean_full: false
+````
 ### Setting permissions
 **Note**: If you specify insufficient permissions the playbook will treat the following play as a new installation because it will not be able to determine what version is installed. 
 To specify the permissions of the codebase, you can set:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Go
 go_reget: false
 go_install_clean: false
+go_install_clean_full: true
 go_version: 1.13.8
 go_uninstall: false
 go_custom_mirror: https://storage.googleapis.com/golang

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -10,6 +10,7 @@
   file:
     path: "{{ GOPATH }}"
     state: absent
+  when: go_install_clean_full
   failed_when: false
 
 - name: "Go-Lang | Removing GOBOOTSTRAP"


### PR DESCRIPTION
go_install_clean causes various parts of a previous install from being removed, but there may be cases where you are testing local modifications in your GOPATH and don't want these removed.

Add a new parameter to prevent GOPATH being removed during cleanup, leaving the default
behaviour remaining the same.