### PR TITLE
Improve usage when running in check mode

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -10,15 +10,9 @@
     fubarhouse_user: "{{ ansible_user_id }}"
   when: ansible_ssh_user is not defined and fubarhouse_user is not defined
 
-- name: "Go-Lang | Get $HOME"
-  command: "echo $HOME"
-  register: shell_home_dir
-  changed_when: false
-  when: fubarhouse_user_dir is not defined
-
 - name: "Go-Lang | Set $HOME"
   set_fact:
-    fubarhouse_user_dir: "{{ shell_home_dir.stdout }}"
+    fubarhouse_user_dir: "{{ ansible_env.HOME }}"
   when: fubarhouse_user_dir is not defined
 
 - name: "Go-Lang | Include OS-Specific tasks (CentOS and Amazon)"


### PR DESCRIPTION
The `command` module doesn't run when running `ansible` with `--check`. This means that the `shell_home_dir` won't get set, resulting in the following error:
```
The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'stdout'
```
This is because we are trying to reference `shell_home_dir.stdout` in the next task, and `shell_home_dir` has not been set.

The fix is to just ditch the `command` module and instead use the `ansible_env.HOME` variable to get the home directory of the ansible user running the role.