### PR TITLE
Add become for tasks that need root access in Debian based system

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -4,6 +4,7 @@
   file:
     path: "{{ GOROOT }}"
     state: absent
+  become: yes
   failed_when: false
 
 - name: "Go-Lang | Removing GOPATH"

--- a/tasks/install-distro.yml
+++ b/tasks/install-distro.yml
@@ -8,11 +8,13 @@
     validate_certs: no
 
 - name: "Go-Lang | Empty destination directory"
+  become: yes
   file:
     path: "{{ GOROOT }}"
     state: absent
 
 - name: "Go-Lang | Ensure directory is writable"
+  become: yes
   file:
     path: "{{ GOROOT }}"
     state: directory
@@ -27,12 +29,14 @@
     copy: "no"
 
 - name: "Go-Lang | Removing existing installation"
+  become: yes
   file:
     path: "{{ GOROOT }}"
     state: absent
   when: not build_go_from_source
 
 - name: "Go-Lang | Moving to installation directory"
+  become: yes
   command: "mv -f {{ go_temporary_dir }}/go {{ GOROOT }}"
   when: not build_go_from_source
 

--- a/tasks/tasks-Debian.yml
+++ b/tasks/tasks-Debian.yml
@@ -5,6 +5,7 @@
     pkg: [ 'curl', 'gcc', 'git', 'findutils', 'make', 'rsync', 'tar' ]
     state: present
   register: apt_result
+  become: yes
   until: apt_result is success
   retries: 1
   delay: 2


### PR DESCRIPTION
I got the installation working on my machine (Ubuntu 20.04) using the following task:

```yaml
# ...
  - name: Install Go
    tags:
      - always
    include_role:
      name: ansible-role-golang
      apply:
        tags:
          - go
    vars:
      go_version: 1.17
      go_install_clean: true
      go_install_clean_full: false
```

Without these changes, one of these tasks woudl fail with some sort of permission issue.

At first, I tried to use `apply: become=yes`, as suggested in #156, but it causes several issues as not being able to write into $GOPATH because the folder's owner would be root etc.

I'm not sure if this will break in other systems...

Also, I think we should use `become: yes` in every play we need to write to or delete things in `$GOROOT`, but I did not make these changes yet. For instance, the tasks at `install-git.yml`.

Closes #156