### PR TITLE
Removed unnecessary go_install_clean

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,6 @@
   when: (not go_binary.stat.exists) or ((current_go_version is not defined) or
         (expected_go_version_output|string not in current_go_version.stdout|default('')) or
         go_install_clean) and
-        (go_install_clean) and
         (not go_uninstall)
 
 - name: "Include tasks for Go Get"


### PR DESCRIPTION
As this is already covered in the previous or-statement.

Without this change, you'll then need to have `go_install_clean` set to `true` to update Go to a newer version.